### PR TITLE
Fixed dismiss error in iOS 8.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ profile
 DerivedData
 *.hmap
 *.ipa
+
+._*
+.DS_Store

--- a/SCUnreadMenu.xcodeproj/project.pbxproj
+++ b/SCUnreadMenu.xcodeproj/project.pbxproj
@@ -250,9 +250,10 @@
 				ORGANIZATIONNAME = "Subjective-C";
 				TargetAttributes = {
 					A804B77718D553D500553B20 = {
-						DevelopmentTeam = 669M58K74Z;
+						DevelopmentTeam = 4E5Q3J5F8B;
 					};
 					A804B79218D553D500553B20 = {
+						DevelopmentTeam = 4E5Q3J5F8B;
 						TestTargetID = A804B77718D553D500553B20;
 					};
 				};

--- a/SCUnreadMenu/SCOverlayPresentTransition.m
+++ b/SCUnreadMenu/SCOverlayPresentTransition.m
@@ -17,11 +17,9 @@
 
 - (void)animateTransition:(id<UIViewControllerContextTransitioning>)transitionContext
 {
-    UIViewController *presentingViewController = [transitionContext viewControllerForKey:UITransitionContextFromViewControllerKey];
     UIViewController *overlayViewController = [transitionContext viewControllerForKey:UITransitionContextToViewControllerKey];
     
     UIView *containerView = [transitionContext containerView];
-    [containerView addSubview:presentingViewController.view];
     [containerView addSubview:overlayViewController.view];
 
     overlayViewController.view.alpha = 0.f;


### PR DESCRIPTION
Fixed dismiss error in iOS 8. Updated .gitignore to ignore dot underscore and 'DS Store' files.

I was running the application on iOS 8 and there was a error. I recorded the error and uploaded it to YouTube. Please check it out: http://youtu.be/aVFSK6C0h2o

The cause seems to be, adding the presenting view controller to the Transition Context's Container View when presenting.

I tested the modified version and it works on both iOS7 and iOS8.
